### PR TITLE
python, README.md: fix & refine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,52 @@
 # gr-lilacsat
----------------------------------------
+
 GNU Radio OOT Module for telemetry decoding of LilacSat-1, LilacSat-2 and BY70-1 satellites.
 
-Tested on GRC 3.7.8 and 3.7.10.1, and ubuntu 14.04 LTS.
+Tested on GRC 3.7.8, 3.7.10.1, and 3.7.13.4, and Ubuntu 14.04 LTS.
 
 Currently this OOT module does not work on ubuntu 16.04 LTS. Please contact me if you can find a solution.
 
-This project is supported by Harbin Institute of Technology.
-
-Visit http://lilacsat.hit.edu.cn/ for more information.
+This project is supported by Harbin Institute of Technology. Visit http://lilacsat.hit.edu.cn/ for more information.
 
 ## Requirements
----------------------------------------
 
 * [gr-satellites](https://github.com/daniestevez/gr-satellites/)
-* [construct 2.8](https://construct.readthedocs.io/en/latest/) For telemetry parser
-* [feh](https://feh.finalrewind.org/) For realtime image display
+* [construct 2.8](https://construct.readthedocs.io/en/latest/) for telemetry parser
+* [feh](https://feh.finalrewind.org/) for realtime image display
 
 ## Examples
----------------------------------------
-frontend_rx_\*.grc in examples folder for different devices:
-* frontend_rx_fcdpp.grc for Funcube Dongle Pro Plus (gr-fcdproplus needed);
-* frontend_rx_uhd.grc for USRP;
-* frontend_rx_rtl.grc for RTL-SDR.
 
-demod_node\*_\*.grc in examples folder for different modulation and rate:
-* demod_node1_bpsk_9k6.grc for 437.200 MHz 9600 bps RRC-BPSK telemetry;
-* demod_node1_afsk.grc for 437.200 MHz 1200 bps AFSK-FM telemetry;
-* demod_node1_ccsds_fm.grc for 437.200 MHz 300 bps subaudio baseband telemetry;
-* demod_node4_4k8.grc for 437.225 MHz 4800 bps GFSK telemetry.
+`frontend_rx_\*.grc` in examples folder for different devices:
+
+* `frontend_rx_fcdpp.grc` for Funcube Dongle Pro Plus (gr-fcdproplus needed);
+* `frontend_rx_uhd.grc` for USRP;
+* `frontend_rx_rtl.grc` for RTL-SDR.
+
+`demod_node\*_\*.grc` in examples folder for different modulation and rate:
+
+* `demod_node1_bpsk_9k6.grc` for 437.200 MHz 9600 bps RRC-BPSK telemetry;
+* `demod_node1_afsk.grc` for 437.200 MHz 1200 bps AFSK-FM telemetry;
+* `demod_node1_ccsds_fm.grc` for 437.200 MHz 300 bps subaudio baseband telemetry;
+* `demod_node4_4k8.grc` for 437.225 MHz 4800 bps GFSK telemetry.
  
-Use frontend_rx_\*.grc, demod_node1_bpsk_9k6.grc and demod_node4_4k8.grc by default.
+Use `frontend_rx_\*.grc`, `demod_node1_bpsk_9k6.grc` and `demod_node4_4k8.grc` by default.
 
-proxy_publish is also included in examples folder for upload telemetry for display.
+`proxy_publish` is also included in examples folder for upload telemetry for display.
 
 ## LilacSat-2 Live CD
----------------------------------------
+
 A Live CD is also provided: http://lilacsat.hit.edu.cn/?page_id=257
 
 Manual: http://lilacsat.hit.edu.cn/wp-content/uploads/2015/09/LilacSat-2_Live_CD_User_Manual.pdf
 
 ## LilacSat-1 Downlink IQ Record
----------------------------------------
+
 A IQ record of LilacSat-1 downlink: https://drive.google.com/open?id=0B_j7kp3QtCNaejVlWDFEVGxiR2M
 
 It can be used for a evaluation of the FM uplink codec2 downlink repeater.
 
 ## BY70-1 Downlink Bit Steam Record
----------------------------------------
+
 A bit stream record of BY70-1 downlink: https://drive.google.com/open?id=0B_j7kp3QtCNaa0I3Nng4b3Z5QTA
 
 It can be used for a evaluation of the telemetry downlink and image downlink.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Visit http://lilacsat.hit.edu.cn/ for more information.
 ## Requirements
 ---------------------------------------
 
-* [gr-csp](https://github.com/daniestevez/gr-csp/)
+* [gr-satellites](https://github.com/daniestevez/gr-satellites/)
 * [construct 2.8](https://construct.readthedocs.io/en/latest/) For telemetry parser
 * [feh](https://feh.finalrewind.org/) For realtime image display
 

--- a/python/camera_telemetry_parser.py
+++ b/python/camera_telemetry_parser.py
@@ -25,7 +25,7 @@ import pmt
 
 import telemetry
 from construct.core import ConstError
-from csp.csp_header import CSP
+from satellites.csp_header import CSP
 import struct
 
 class camera_telemetry_parser(gr.basic_block):

--- a/python/image_decoder.py
+++ b/python/image_decoder.py
@@ -24,7 +24,7 @@ import os.path
 import binascii
 import subprocess
 
-from csp.csp_header import CSP
+from satellites.csp_header import CSP
 
 import numpy
 from gnuradio import gr

--- a/python/telemetry.py
+++ b/python/telemetry.py
@@ -153,7 +153,7 @@ Cfg = Struct(Const(b'\x1c\xa2'),\
              'interval_hk_OBC' / Int32ul,\
              'interval_hk_TLM' / Int32ul,\
              'interval_hk_BEACON' / Int32ul,\
-             'message' / String(28),\
+             'message' / PascalString(28, "utf8"),\
              'cam_delay' / Int32ul,\
              'crc' / Int32ul)
 

--- a/python/telemetry_parser.py
+++ b/python/telemetry_parser.py
@@ -25,7 +25,7 @@ import pmt
 
 import telemetry
 from construct.core import ConstError
-from csp.csp_header import CSP
+from satellites.csp_header import CSP
 import struct
 
 class telemetry_parser(gr.basic_block):


### PR DESCRIPTION
This PR:

- Fixes import error in several python modules, where gr_csp is used but is deprecated now.
- Changes (older?) `String` to (newer?) `PascalString`. `String` is a type from Python module `construct`, but it seems to be deprecated from recent versions.
- Updates README.md about the switch of dependency, and fixes Markdown grammar. My GNU Radio version is also added for reference.